### PR TITLE
preserve n + 1 carriage returns

### DIFF
--- a/src/components/ContentEditor/index.js
+++ b/src/components/ContentEditor/index.js
@@ -6,7 +6,6 @@ import {
   RichUtils,
   AtomicBlockUtils,
   Modifier,
-  DefaultDraftBlockRenderMap,
   convertToRaw
 } from 'draft-js';
 


### PR DESCRIPTION
Since the editor doesn't support self-closing tags internally, we'll convert any n +1 empty `<p>`s into `<br>`s on export so that our embedded html preserves carriage returns by default.